### PR TITLE
SqrlStorage::load continues with invalid header

### DIFF
--- a/src/SqrlStorage.cpp
+++ b/src/SqrlStorage.cpp
@@ -156,7 +156,9 @@ namespace libsqrl
                 SqrlString buf( buffer );
                 buf.erase( 0, 8 );
                 SqrlBase64().decode( buffer, &buf );
-            }
+            }else{
+                return false; // not valid sqrl data
+            }            
         }
 
         const uint8_t * cur = buffer->cdata();


### PR DESCRIPTION
it correctly handles 'SQRLDATA' and 'sqrldata' but not 'deadbeef' (for example)

I am not certain this change is the best way to handle the problem, but ignoring it is worse.
